### PR TITLE
Make the download URL regexp more specific

### DIFF
--- a/download.py
+++ b/download.py
@@ -11,11 +11,11 @@ import xml.etree.ElementTree as ET
 class Downloader:
 
     def __init__(self, url, outdir):
-        m = re.match(r'^.*/playback/presentation/2\.0/playback.html\?meetingId=(\S+)$', url)
+        m = re.match(r'^.*/playback/presentation/2\.0/playback\.html\?meetingId=(\S+)$', url)
         if m is not None:
             id = m.group(1)
         else:
-            m = re.match(r'.*/playback/presentation/2.3/(\S+)$', url)
+            m = re.match(r'^.*/playback/presentation/2\.3/(\S+)$', url)
             if m is not None:
                 id = m.group(1)
             else:


### PR DESCRIPTION
Backslash-escape additional dots for v2.0 and v2.3 URLs, and add a caret for v2.3 URLs.

Note that the regexps before this commit will work just fine. They just match slightly too loosely, e.g. on the string `"2a3"` instead of `"2.3"`.

-------------------

Random side note for v2.0 download URLs: `download.py` imports `urllib.parse` anyway, so it could use `.urlparse` or `.urlsplit` to parse the `query` part of the URL. This is the string `"meetingId="`, followed by the desired id. This doesn't help with v2.3 download URLs though.