### PR TITLE
fixes #17 fix opening credits start time

### DIFF
--- a/make-xges.py
+++ b/make-xges.py
@@ -355,7 +355,7 @@ class Presentation:
             width, height = self._constrain(
                 dims, (self.opts.width, self.opts.height))
 
-            self._add_clip(layer, asset, 0, 0, duration,
+            self._add_clip(layer, asset, self.start_time, 0, duration,
                            0, 0, width, height, trim_end=False)
             self.opening_length += duration
 


### PR DESCRIPTION
it seems opening credits was removed due to following condition:

```
        # Skip clips entirely before the start point
        if start + duration < self.start_time:
            return
```

Moving start time of opening credits helps