### PR TITLE
Changed the way the items are downloaded

### DIFF
--- a/download.py
+++ b/download.py
@@ -61,16 +61,22 @@ class Downloader:
         for imgurl in {img.get('{http://www.w3.org/1999/xlink}href')
                        for img in doc.iterfind('.//{http://www.w3.org/2000/svg}image')}:
             self._get(imgurl)
-
-        self._get('panzooms.xml')
-        self._get('cursor.xml')
-        self._get('deskshare.xml')
-        self._get('presentation_text.json')
-        self._get('captions.json')
-        self._get('slides_new.xml')
-
-        self._get('video/webcams.webm')
-        self._get('deskshare/deskshare.webm')
+        
+        components = ['panzooms.xml',
+                      'cursor.xml',
+                      'deskshare.xml',
+                      'presentation_text.json',
+                      'captions.json',
+                      'slides_new.xml',
+                      'video/webcams.webm',
+                      'deskshare/deskshare.webm']
+        
+        for item in components:
+            try:
+                self._get(item)
+            except Exception:
+                f"Component {item} not available in presentation"
+        
 
 
 def main(argv):


### PR DESCRIPTION
This other methods is safer, the code will not break if a component is missing and can't be downloaded.
As you can see below the code fails at line 73, where the seflf_get() method is called on the missing deskshare.webm.
Nesting all the components in a try by using a for loop, seems to be the safest way to do this.

```
$ python download.py https://**redacted**/playback/presentation/2.3/b4fbf357166b916dd0460ce69e2c7c09fcd8b55f-1644219908384 outu
Downloading https://**redacted**/presentation/b4fbf357166b916dd0460ce69e2c7c09fcd8b55f-1644219908384/metadata.xml...
Downloading https://**redacted**/presentation/b4fbf357166b916dd0460ce69e2c7c09fcd8b55f-1644219908384/shapes.svg...
Downloading https://**redacted**/presentation/b4fbf357166b916dd0460ce69e2c7c09fcd8b55f-1644219908384/presentation/44bd52a9a4d77104fbb1b7eca7475a453ce1c95c-1644220733306/slide-1.png...
Downloading https://**redacted**/presentation/b4fbf357166b916dd0460ce69e2c7c09fcd8b55f-1644219908384/panzooms.xml...
Downloading https://**redacted**/presentation/b4fbf357166b916dd0460ce69e2c7c09fcd8b55f-1644219908384/cursor.xml...
Downloading https://**redacted**/presentation/b4fbf357166b916dd0460ce69e2c7c09fcd8b55f-1644219908384/deskshare.xml...
Downloading https://**redacted**/presentation/b4fbf357166b916dd0460ce69e2c7c09fcd8b55f-1644219908384/presentation_text.json...
Downloading https://**redacted**/presentation/b4fbf357166b916dd0460ce69e2c7c09fcd8b55f-1644219908384/captions.json...
Downloading https://**redacted**/presentation/b4fbf357166b916dd0460ce69e2c7c09fcd8b55f-1644219908384/slides_new.xml...
Downloading https://**redacted**/presentation/b4fbf357166b916dd0460ce69e2c7c09fcd8b55f-1644219908384/video/webcams.webm...
Downloading https://**redacted**/presentation/b4fbf357166b916dd0460ce69e2c7c09fcd8b55f-1644219908384/deskshare/deskshare.webm...
Traceback (most recent call last):
  File "download.py", line 85, in <module>
    sys.exit(main(sys.argv))
  File "download.py", line 81, in main
    d.download()
  File "download.py", line 73, in download
    self._get('deskshare/deskshare.webm')
  File "download.py", line 38, in _get
    resp = urllib.request.urlopen(req)
  File "/usr/lib/python3.8/urllib/request.py", line 222, in urlopen
    return opener.open(url, data, timeout)
  File "/usr/lib/python3.8/urllib/request.py", line 531, in open
    response = meth(req, response)
  File "/usr/lib/python3.8/urllib/request.py", line 640, in http_response
    response = self.parent.error(
  File "/usr/lib/python3.8/urllib/request.py", line 569, in error
    return self._call_chain(*args)
  File "/usr/lib/python3.8/urllib/request.py", line 502, in _call_chain
    result = func(*args)
  File "/usr/lib/python3.8/urllib/request.py", line 649, in http_error_default
    raise HTTPError(req.full_url, code, msg, hdrs, fp)
urllib.error.HTTPError: HTTP Error 404: Not Found

```